### PR TITLE
fix(auth): implement proper sign-out navigation

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -2,11 +2,13 @@ import 'package:flutter/material.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:provider/provider.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
+import 'package:tapeats/presentation/screens/login_page.dart';
 import 'package:tapeats/presentation/state_management/cart_state.dart';
 import 'package:tapeats/presentation/state_management/navbar_state.dart';
 import 'package:tapeats/presentation/state_management/slider_state.dart';
 import 'package:tapeats/utils/env_loader.dart';
-import 'presentation/screens/splash_screen.dart';
+import 'package:tapeats/presentation/screens/splash_screen.dart';
+import 'package:tapeats/presentation/screens/user_side/main_screen.dart';
 
 // Add RouteObserver instance at the top level
 final RouteObserver<PageRoute> routeObserver = RouteObserver<PageRoute>();
@@ -58,7 +60,19 @@ class MyApp extends StatelessWidget {
       initialRoute: '/',
       routes: {
         '/': (context) => const SplashScreen(selectedIndex: 0),
-        // Add other routes as needed
+        '/auth/login': (context) => const LoginPage(),
+        '/home': (context) => MainScreen(),
+      },
+      // Handle undefined routes
+      onUnknownRoute: (settings) {
+        return MaterialPageRoute(
+          builder: (context) => const SplashScreen(selectedIndex: 0),
+        );
+      },
+      // Optional: Add onGenerateRoute for dynamic routes if needed
+      onGenerateRoute: (settings) {
+        // Handle any dynamic routes here
+        return null;
       },
     );
   }


### PR DESCRIPTION
## Changes Made
- Added `/auth/login` route registration in MaterialApp routes configuration
- Implemented proper route handling and onUnknownRoute in main.dart
- Added error handling with visual feedback for failed sign-out attempts
- Implemented clean animation and navigation sequence for sign-out

## Implementation Details
- Updated main.dart with proper route registration
- Modified sign-out flow to properly handle state and navigation
- Added user feedback via Snackbar for error cases
- Ensured proper cleanup of navigation stack during sign-out

## Testing Done
- Verified successful sign-out and navigation to login page
- Tested error scenarios and confirmed error messages display
- Validated navigation stack is properly cleared
- Confirmed no remaining overlay issues
- Tested app restart scenario

## Technical Notes
- Uses named route navigation for consistency
- Implements proper error handling and mounted checks
- Maintains animation smoothness during transition
- Properly handles Supabase auth state

Fixes #21
Related to #5